### PR TITLE
Fix megaface eval as only one out is returned

### DIFF
--- a/evaluation/infer/citrus_base_infer.py
+++ b/evaluation/infer/citrus_base_infer.py
@@ -168,8 +168,7 @@ class inferThread (threading.Thread):
             if idx == 0:
               continue
 
-            output = self.fwd_func(self.net, input_blob)
-            embedding = output[0]
+            embedding = self.fwd_func(self.net, input_blob)
     
             if self.is_flip:
                 embedding1 = embedding[0::2]


### PR DESCRIPTION
This was changed recently (but before this was pushed) to have only one output. So pulling first element now breaks it.

I had to make numerous changes to get this to work with Python 3 but I believe this change would break in both.
I also have an issue where it finds the GPU free memory size in MB instead of in GB but haven't investigated.